### PR TITLE
fix console pycodestyle 

### DIFF
--- a/1-pack_web_static.py
+++ b/1-pack_web_static.py
@@ -18,5 +18,5 @@ def do_pack():
         file_name = "versions/web_static_{}.tgz".format(date)
         local("tar -cvzf {} web_static".format(file_name))
         return file_name
-    except:
+    except BaseException:
         return None

--- a/2-do_deploy_web_static.py
+++ b/2-do_deploy_web_static.py
@@ -26,5 +26,5 @@ def do_deploy(archive_path):
         run('rm -rf /data/web_static/current')
         run('ln -s {}{}/ /data/web_static/current'.format(path, no_ext))
         return True
-    except:
+    except BaseException:
         return False

--- a/3-deploy_web_static.py
+++ b/3-deploy_web_static.py
@@ -19,7 +19,7 @@ def do_pack():
         file_name = "versions/web_static_{}.tgz".format(date)
         local("tar -cvzf {} web_static".format(file_name))
         return file_name
-    except:
+    except BaseException:
         return None
 
 
@@ -40,7 +40,7 @@ def do_deploy(archive_path):
         run('rm -rf /data/web_static/current')
         run('ln -s {}{}/ /data/web_static/current'.format(path, no_ext))
         return True
-    except:
+    except BaseException:
         return False
 
 

--- a/console.py
+++ b/console.py
@@ -46,10 +46,10 @@ class HBNBCommand(cmd.Cmd):
                 else:
                     try:
                         value = int(value)
-                    except:
+                    except BaseException:
                         try:
                             value = float(value)
-                        except:
+                        except BaseException:
                             continue
                 new_dict[key] = value
         return new_dict
@@ -140,12 +140,12 @@ class HBNBCommand(cmd.Cmd):
                                 if args[2] in integers:
                                     try:
                                         args[3] = int(args[3])
-                                    except:
+                                    except BaseException:
                                         args[3] = 0
                                 elif args[2] in floats:
                                     try:
                                         args[3] = float(args[3])
-                                    except:
+                                    except BaseException:
                                         args[3] = 0.0
                             setattr(models.storage.all()[k], args[2], args[3])
                             models.storage.all()[k].save()
@@ -159,6 +159,7 @@ class HBNBCommand(cmd.Cmd):
                 print("** instance id missing **")
         else:
             print("** class doesn't exist **")
+
 
 if __name__ == '__main__':
     HBNBCommand().cmdloop()


### PR DESCRIPTION
1-pack_web_static.py:21:5: E722 do not use bare 'except'
2-do_deploy_web_static.py:29:5: E722 do not use bare 'except'
3-deploy_web_static.py:22:5: E722 do not use bare 'except'
3-deploy_web_static.py:43:5: E722 do not use bare 'except'
console.py:49:21: E722 do not use bare 'except'
console.py:52:25: E722 do not use bare 'except'
console.py:143:37: E722 do not use bare 'except'
console.py:148:37: E722 do not use bare 'except'
console.py:163:1: E305 expected 2 blank lines after class or function definition, found 1